### PR TITLE
Exclude private members from documentation and update docs README

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -5,11 +5,10 @@ PROJECT_ICON           = favicon.ico
 OUTPUT_DIRECTORY       = doc_out
 STRIP_FROM_PATH        = ../
 EXTRACT_ALL            = YES
-EXTRACT_PRIVATE        = YES
-EXTRACT_PRIV_VIRTUAL   = YES
 EXTRACT_STATIC         = YES
 CASE_SENSE_NAMES       = YES
-INPUT                  = ../README.md ../firmware
+INPUT                  = ../README.md \
+                         ../firmware
 RECURSIVE              = YES
 USE_MDFILE_AS_MAINPAGE = README.md
 HTML_HEADER            = template/custom_header.html

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,11 @@ To build the documentation, invoke:
 ````
 doxygen
 ````
+
+## Deployment
+
+Documentation will automatically publish to GitHub Pages when:
+
+* A release is made.
+* A manual workflow dispatch is initiated and publishing is enabled.
+* Any push to any branch is made when `CONTINUOUS_DOCUMENTATION` is enabled (intended for use in forks for development purposes).


### PR DESCRIPTION
Here we temporarily reduce documentation complexity by excluding private members. Later we can explore different ways of grouping sections in docs so we can include everything.

The docs README has also been updated with overall publishing and testing instructions for developers.